### PR TITLE
Correcting send_media_group

### DIFF
--- a/telebot/apihelper.py
+++ b/telebot/apihelper.py
@@ -6,6 +6,7 @@ except ImportError:
     import json
 
 import requests
+import re
 
 try:
     from requests.packages.urllib3 import fields
@@ -107,6 +108,52 @@ def download_file(token, file_path):
         raise ApiException(msg, 'Download file', result)
     return result.content
 
+def getExtension(file):
+    res = re.split('\.', file)
+    return res[len(res)-1]
+
+def uploadImage(filename):
+    fileExtension = 'image/{}'.format(getExtension(filename))
+    with open(filename, 'rb') as f:
+        r = requests.post(
+                url = 'http://telegra.ph/upload',
+                files={'file': ('file', f, fileExtension)}
+            ).json()
+    URL = 'telegra.ph{}'.format(r[0]['src'])
+    return URL
+
+def uploadVideo(filename):
+    fileExtension = 'video/{}'.format(getExtension(filename))
+    with open(filename, 'rb') as f:
+        r = requests.post(
+                url = 'http://telegra.ph/upload',
+                files={'file': ('file', f, fileExtension)}
+            ).json()
+    URL = 'telegra.ph{}'.format(r[0]['src'])
+    return URL
+
+def file_to_send(files, text):
+    files_to_send = []
+    if len(files) > 9:
+        raise ValueError ('Too many files')
+        pass
+    else:
+        photoExtensions = ['gif', 'jpeg', 'jpg', 'png'] # photo extensions
+        videoExtensions = ['mp4'] # video extensions
+        for i in files:
+            print(i)
+            url = None
+            if len(files_to_send) > 0:
+                text = ''
+            if getExtension(i) in photoExtensions:
+                url = uploadImage(i)
+                files_to_send.append(telebot.types.InputMediaPhoto(url, caption=text))
+            elif getExtension(i) in videoExtensions:
+                url = uploadVideo(i)
+                files_to_send.append(telebot.types.InputMediaVideo(url, caption=text))
+            else:
+                raise ValueError ('Unrecognizable file extension')
+    return files_to_send
 
 def send_message(token, chat_id, text, disable_web_page_preview=None, reply_to_message_id=None, reply_markup=None,
                  parse_mode=None, disable_notification=None):
@@ -257,6 +304,10 @@ def send_photo(token, chat_id, photo, caption=None, reply_to_message_id=None, re
 
 def send_media_group(token, chat_id, media, disable_notification=None, reply_to_message_id=None):
     method_url = r'sendMediaGroup'
+    try:
+        media_list = files_to_send(media, caption)
+    except Exception as e:
+        media_list = media
     media_json = _convert_list_json_serializable(media)
     payload = {'chat_id': chat_id, 'media': media_json}
     if disable_notification:


### PR DESCRIPTION
Added automated formatting files for `send_media_group`. User just provide files's names in `media` list (or way to the each file) and they will be automatically uploaded to telegra.ph/upload and will be sent to Telegram using such Bot API feature as uploading data byURL (https://core.telegram.org/bots/api#sending-files) so size limits are the same: 5 MB max size for photos and 20 MB max for other types of content.
Supported file extensions are: 
GIF, JPEG, JPG, PNG and MP4. 
Also added caption support for `send_media_group`. Now user can provide some text as `caption` param in send_media_group and it will be set as first file descrption. Limits are standart (0-200 characters). 